### PR TITLE
Remove `?si=` share ID from YouTube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ It's important to note that profiles are always linked to a parent user, which i
 
 For more information on how to develop apps that work seamlessly with Work Profiles, refer to the [Android for Business documentation](https://developer.android.com/work).
 
-To learn more about the differences between User Profiles and Work Profiles in GrapheneOS, watch this [video guide](https://youtu.be/20C0FD7mGDY?si=TsprE4i3kJlc3iZP).
+To learn more about the differences between User Profiles and Work Profiles in GrapheneOS, watch this [video guide](https://youtu.be/20C0FD7mGDY).
 
 ### Troubleshooting App Compatibility
 


### PR DESCRIPTION
`si` probably means "share ID", which has been added to video URL links when copying from YouTube

Couldn't find documentation from YouTube, but found discussion of this on Reddit:
* [Source 1](https://old.reddit.com/r/youtube/comments/16mgjno/what_is_si_that_appeared_recently_when_sharing_a/)
* [Source 2](https://old.reddit.com/r/youtube/comments/1628878/whats_with_the_si_at_the_end_of_a_link/)